### PR TITLE
removed challenge ID from resources update call

### DIFF
--- a/src/services/ProcessorService.js
+++ b/src/services/ProcessorService.js
@@ -60,7 +60,7 @@ async function updateSelfServiceDataScienceManager (challenge) {
   if (challenge.legacy.selfService && challenge.tags.includes('Data Science')) {
     const m2mToken = await helper.getM2MToken()
     for (const handle of config.DATA_SCIENCE_MANAGER_HANDLES) {
-      await helper.postRequest(`${config.RESOURCE_API_URL}/${challenge.id}`, { challengeId: challenge.id, memberHandle: handle, roleId: config.DATA_SCIENCE_ROLE_ID }, m2mToken)
+      await helper.postRequest(`${config.RESOURCE_API_URL}`, { challengeId: challenge.id, memberHandle: handle, roleId: config.DATA_SCIENCE_ROLE_ID }, m2mToken)
     }
   }
 }


### PR DESCRIPTION
Seems resources API call does not use challenge ID as a  url param when posting or updating a resource role.